### PR TITLE
Fixed: enumerate method

### DIFF
--- a/WatchKitTableDemo WatchKit Extension/InterfaceController.swift
+++ b/WatchKitTableDemo WatchKit Extension/InterfaceController.swift
@@ -20,7 +20,7 @@ class InterfaceController: WKInterfaceController {
         
         minionTable.setNumberOfRows(minions.count, withRowType: "MinionTableRowController")
         
-        for (index, minionName) in enumerate(minions) {
+        for (index, minionName) in minions.enumerate() {
             
             let row = minionTable.rowControllerAtIndex(index) as! MinionTableRowController
             


### PR DESCRIPTION
Swift 2.0 changed enumerate method access :
from :
enumerate(array)
to :
array.enumerate()
